### PR TITLE
Update Status Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,14 @@ Part of [GameCI](https://game.ci).
 
 | Description             | Done | Status |
 |-------------------------|------|--------|
-| [Build for WebGL](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#webgl) |
-| [Build for Windows](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#windows) |
-| [Build for Linux](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#linux) |
-| [Build for MacOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#macos) |
-| [Build for Android](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#android) |
-| [Build for iOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/game-ci/unity-builder/workflows/Builds/badge.svg?event=push&branch=main)](https://github.com/game-ci/unity-builder#ios) |
-| [Build for Windows store](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |
-| [Build for tvOS](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |
-| [Build for PS4](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
-| [Build for XboxOne](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
-| [Build for Switch](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
+| [Build for WebGL](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for Windows](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for Linux](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for MacOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for Android](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for iOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
+| [Build for Windows store](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml) |
+| [Build for tvOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml) |
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Part of [GameCI](https://game.ci).
 | [Build for iOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/build-tests.yml) |
 | [Build for Windows store](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml) |
 | [Build for tvOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions Status](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml/badge.svg?branch=main)](https://github.com/game-ci/unity-builder/actions/workflows/windows-build-tests.yml) |
+| [Build for Xbox](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
+| [Build for Playstation](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
+| [Build for Switch](https://github.com/marketplace/actions/unity-builder) | ❌ | Requires license |
 
 ## How to use
 


### PR DESCRIPTION
#### Changes

- Use latest workflows badges
- Removed XboxOne, PS4, and Switch. 
  - XboxOne and PS4 are outdated hardware, where there are few if any developers interested in building for this hardware anymore. We could obviously replace them with Xbox Series X and PS5, but I think it is better to simply remove them. If any progress is made towards those platforms, the status can be updated again.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
